### PR TITLE
Update NCS branch from master to main

### DIFF
--- a/nrfconnect-chip/Dockerfile
+++ b/nrfconnect-chip/Dockerfile
@@ -31,7 +31,7 @@
 ARG BASE
 FROM ${BASE}
 
-ARG NCS_REVISION="master"
+ARG NCS_REVISION="main"
 ARG CHIP_REVISION="master"
 ARG GN_BUILD_URL="https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest"
 

--- a/nrfconnect-toolchain/Dockerfile
+++ b/nrfconnect-toolchain/Dockerfile
@@ -32,7 +32,7 @@ FROM ubuntu:21.04
 
 ARG TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2"
 ARG NRF_TOOLS_URL="https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-14-0/nRF-Command-Line-Tools_10_14_0_Linux64.zip"
-ARG NCS_REVISION="master"
+ARG NCS_REVISION="main"
 
 RUN set -x \
     #


### PR DESCRIPTION
Caused by https://github.com/nrfconnect/sdk-nrf/commit/ea83b7edbce161873baec8828400579f8c96f035 which changed sdk-nrf's default branch.

```
...
+ west init -m https://github.com/nrfconnect/sdk-nrf --mr master
=== Initializing in /tmp/ncs
--- Cloning manifest repository from https://github.com/nrfconnect/sdk-nrf, rev. master
Cloning into '/tmp/ncs/.west/manifest-tmp'...
fatal: Remote branch master not found in upstream origin
FATAL ERROR: command exited with status 128: git clone --branch master https://github.com/nrfconnect/sdk-nrf /tmp/ncs/.west/manifest-tmp
```