### PR TITLE
Downgrade ubuntu to 20.04

### DIFF
--- a/nrfconnect-toolchain/Dockerfile
+++ b/nrfconnect-toolchain/Dockerfile
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-FROM ubuntu:21.04
+FROM ubuntu:20.04
 
 ARG TOOLCHAIN_MD5="fe0029de4f4ec43cf7008944e34ff8cc"
 ARG TOOLCHAIN_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2019q4/gcc-arm-none-eabi-9-2019-q4-major-x86_64-linux.tar.bz2"


### PR DESCRIPTION
Building software on 21.04 Docker causes issues with running
it on hosts with Ubuntu 20.04 which apparently is still used
by people.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>